### PR TITLE
feat: Add ability to require scopes for specific PR types only

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,13 +18,13 @@ jobs:
         with:
           node-version: 16
       - run: yarn install
-      - run: yarn lint && yarn test
+      - run: yarn test
 
   dist:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-        with: 
+        with:
           fetch-depth: 0
       - name: Check if `dist/` has been modified.
         run: |

--- a/src/validatePrTitle.test.js
+++ b/src/validatePrTitle.test.js
@@ -6,7 +6,7 @@ it('allows valid PR titles that use the default types', async () => {
     'fix!: Fix bug',
     'feat: Add feature',
     'feat!: Add feature',
-    'refactor: Internal cleanup'
+    'refactor: Internal cleanup',
   ];
 
   for (let index = 0; index < inputs.length; index++) {
@@ -48,32 +48,32 @@ describe('defined scopes', () => {
   });
 
   it('allows a missing scope when custom scopes are defined', async () => {
-    await validatePrTitle('fix: Bar', {scopes: ['foo']});
+    await validatePrTitle('fix: Bar', { scopes: ['foo'] });
   });
 
   it('allows a matching scope', async () => {
-    await validatePrTitle('fix(core): Bar', {scopes: ['core']});
+    await validatePrTitle('fix(core): Bar', { scopes: ['core'] });
   });
 
   it('allows a regex matching scope', async () => {
-    await validatePrTitle('fix(CORE): Bar', {scopes: ['[A-Z]+']});
+    await validatePrTitle('fix(CORE): Bar', { scopes: ['[A-Z]+'] });
   });
 
   it('allows multiple matching scopes', async () => {
     await validatePrTitle('fix(core,e2e): Bar', {
-      scopes: ['core', 'e2e', 'web']
+      scopes: ['core', 'e2e', 'web'],
     });
   });
 
   it('allows multiple regex matching scopes', async () => {
     await validatePrTitle('fix(CORE,WEB): Bar', {
-      scopes: ['[A-Z]+']
+      scopes: ['[A-Z]+'],
     });
   });
 
   it('throws when an unknown scope is detected within multiple scopes', async () => {
     await expect(
-      validatePrTitle('fix(core,e2e,foo,bar): Bar', {scopes: ['foo', 'core']})
+      validatePrTitle('fix(core,e2e,foo,bar): Bar', { scopes: ['foo', 'core'] })
     ).rejects.toThrow(
       'Unknown scopes "e2e,bar" found in pull request title "fix(core,e2e,foo,bar): Bar". Scope must match one of: foo, core.'
     );
@@ -82,7 +82,7 @@ describe('defined scopes', () => {
   it('throws when an unknown scope is detected within multiple scopes', async () => {
     await expect(
       validatePrTitle('fix(CORE,e2e,foo,bar): Bar', {
-        scopes: ['foo', '[A-Z]+']
+        scopes: ['foo', '[A-Z]+'],
       })
     ).rejects.toThrow(
       'Unknown scopes "e2e,bar" found in pull request title "fix(CORE,e2e,foo,bar): Bar". Scope must match one of: foo, [A-Z]+.'
@@ -91,7 +91,7 @@ describe('defined scopes', () => {
 
   it('throws when an unknown scope is detected', async () => {
     await expect(
-      validatePrTitle('fix(core): Bar', {scopes: ['foo']})
+      validatePrTitle('fix(core): Bar', { scopes: ['foo'] })
     ).rejects.toThrow(
       'Unknown scope "core" found in pull request title "fix(core): Bar". Scope must match one of: foo.'
     );
@@ -99,7 +99,7 @@ describe('defined scopes', () => {
 
   it('throws when an unknown scope is detected for auto-wrapped regex matching', async () => {
     await expect(
-      validatePrTitle('fix(score): Bar', {scopes: ['core']})
+      validatePrTitle('fix(score): Bar', { scopes: ['core'] })
     ).rejects.toThrow(
       'Unknown scope "score" found in pull request title "fix(score): Bar". Scope must match one of: core.'
     );
@@ -107,7 +107,7 @@ describe('defined scopes', () => {
 
   it('throws when an unknown scope is detected for auto-wrapped regex matching when input is already wrapped', async () => {
     await expect(
-      validatePrTitle('fix(score): Bar', {scopes: ['^[A-Z]+$']})
+      validatePrTitle('fix(score): Bar', { scopes: ['^[A-Z]+$'] })
     ).rejects.toThrow(
       'Unknown scope "score" found in pull request title "fix(score): Bar". Scope must match one of: ^[A-Z]+$.'
     );
@@ -115,7 +115,7 @@ describe('defined scopes', () => {
 
   it('throws when an unknown scope is detected for regex matching', async () => {
     await expect(
-      validatePrTitle('fix(core): Bar', {scopes: ['[A-Z]+']})
+      validatePrTitle('fix(core): Bar', { scopes: ['[A-Z]+'] })
     ).rejects.toThrow(
       'Unknown scope "core" found in pull request title "fix(core): Bar". Scope must match one of: [A-Z]+.'
     );
@@ -126,7 +126,7 @@ describe('defined scopes', () => {
       it('passes when a scope is provided', async () => {
         await validatePrTitle('fix(core): Bar', {
           scopes: ['core'],
-          requireScope: true
+          requireScope: true,
         });
       });
 
@@ -134,63 +134,73 @@ describe('defined scopes', () => {
         await expect(
           validatePrTitle('fix: Bar', {
             scopes: ['foo', 'bar'],
-            requireScope: true
+            requireScope: true,
           })
         ).rejects.toThrow(
           'No scope found in pull request title "fix: Bar". Scope must match one of: foo, bar.'
         );
       });
+
+      it('passes when a scope is missing, but not required for the type', async () => {
+        await validatePrTitle('feat: Bar', {
+          scopes: ['foo', 'bar'],
+          requireScope: true,
+          typesRequiringScope: ['chore'],
+        });
+      });
     });
 
     describe('disallow scopes', () => {
       it('passes when a single scope is provided, but not present in disallowScopes with one item', async () => {
-        await validatePrTitle('fix(core): Bar', {disallowScopes: ['release']});
+        await validatePrTitle('fix(core): Bar', {
+          disallowScopes: ['release'],
+        });
       });
 
       it('passes when a single scope is provided, but not present in disallowScopes with one regex item', async () => {
-        await validatePrTitle('fix(core): Bar', {disallowScopes: ['[A-Z]+']});
+        await validatePrTitle('fix(core): Bar', { disallowScopes: ['[A-Z]+'] });
       });
 
       it('passes when multiple scopes are provided, but not present in disallowScopes with one item', async () => {
         await validatePrTitle('fix(core,e2e,bar): Bar', {
-          disallowScopes: ['release']
+          disallowScopes: ['release'],
         });
       });
 
       it('passes when multiple scopes are provided, but not present in disallowScopes with one regex item', async () => {
         await validatePrTitle('fix(core,e2e,bar): Bar', {
-          disallowScopes: ['[A-Z]+']
+          disallowScopes: ['[A-Z]+'],
         });
       });
 
       it('passes when a single scope is provided, but not present in disallowScopes with multiple items', async () => {
         await validatePrTitle('fix(core): Bar', {
-          disallowScopes: ['release', 'test', '[A-Z]+']
+          disallowScopes: ['release', 'test', '[A-Z]+'],
         });
       });
 
       it('passes when multiple scopes are provided, but not present in disallowScopes with multiple items', async () => {
         await validatePrTitle('fix(core,e2e,bar): Bar', {
-          disallowScopes: ['release', 'test', '[A-Z]+']
+          disallowScopes: ['release', 'test', '[A-Z]+'],
         });
       });
 
       it('throws when a single scope is provided and it is present in disallowScopes with one item', async () => {
         await expect(
-          validatePrTitle('fix(release): Bar', {disallowScopes: ['release']})
+          validatePrTitle('fix(release): Bar', { disallowScopes: ['release'] })
         ).rejects.toThrow('Disallowed scope was found: release');
       });
 
       it('throws when a single scope is provided and it is present in disallowScopes with one regex item', async () => {
         await expect(
-          validatePrTitle('fix(RELEASE): Bar', {disallowScopes: ['[A-Z]+']})
+          validatePrTitle('fix(RELEASE): Bar', { disallowScopes: ['[A-Z]+'] })
         ).rejects.toThrow('Disallowed scope was found: RELEASE');
       });
 
       it('throws when a single scope is provided and it is present in disallowScopes with multiple item', async () => {
         await expect(
           validatePrTitle('fix(release): Bar', {
-            disallowScopes: ['release', 'test']
+            disallowScopes: ['release', 'test'],
           })
         ).rejects.toThrow('Disallowed scope was found: release');
       });
@@ -198,7 +208,7 @@ describe('defined scopes', () => {
       it('throws when a single scope is provided and it is present in disallowScopes with multiple regex item', async () => {
         await expect(
           validatePrTitle('fix(RELEASE): Bar', {
-            disallowScopes: ['[A-Z]+', '^[A-Z].+$']
+            disallowScopes: ['[A-Z]+', '^[A-Z].+$'],
           })
         ).rejects.toThrow('Disallowed scope was found: RELEASE');
       });
@@ -206,7 +216,7 @@ describe('defined scopes', () => {
       it('throws when multiple scopes are provided and one of them is present in disallowScopes with one item ', async () => {
         await expect(
           validatePrTitle('fix(release,e2e): Bar', {
-            disallowScopes: ['release']
+            disallowScopes: ['release'],
           })
         ).rejects.toThrow('Disallowed scope was found: release');
       });
@@ -214,7 +224,7 @@ describe('defined scopes', () => {
       it('throws when multiple scopes are provided and one of them is present in disallowScopes with one regex item ', async () => {
         await expect(
           validatePrTitle('fix(RELEASE,e2e): Bar', {
-            disallowScopes: ['[A-Z]+']
+            disallowScopes: ['[A-Z]+'],
           })
         ).rejects.toThrow('Disallowed scope was found: RELEASE');
       });
@@ -222,7 +232,7 @@ describe('defined scopes', () => {
       it('throws when multiple scopes are provided and one of them is present in disallowScopes with multiple items ', async () => {
         await expect(
           validatePrTitle('fix(release,e2e): Bar', {
-            disallowScopes: ['release', 'test']
+            disallowScopes: ['release', 'test'],
           })
         ).rejects.toThrow('Disallowed scope was found: release');
       });
@@ -230,7 +240,7 @@ describe('defined scopes', () => {
       it('throws when multiple scopes are provided and one of them is present in disallowScopes with multiple items ', async () => {
         await expect(
           validatePrTitle('fix(RELEASE,e2e): Bar', {
-            disallowScopes: ['[A-Z]+', 'test']
+            disallowScopes: ['[A-Z]+', 'test'],
           })
         ).rejects.toThrow('Disallowed scope was found: RELEASE');
       });
@@ -238,7 +248,7 @@ describe('defined scopes', () => {
       it('throws when multiple scopes are provided and more than one of them are present in disallowScopes', async () => {
         await expect(
           validatePrTitle('fix(release,test,CORE): Bar', {
-            disallowScopes: ['release', 'test', '[A-Z]+']
+            disallowScopes: ['release', 'test', '[A-Z]+'],
           })
         ).rejects.toThrow('Disallowed scopes were found: release, test, CORE');
       });
@@ -247,14 +257,14 @@ describe('defined scopes', () => {
     describe('scope allowlist not defined', () => {
       it('passes when a scope is provided', async () => {
         await validatePrTitle('fix(core): Bar', {
-          requireScope: true
+          requireScope: true,
         });
       });
 
       it('throws when a scope is missing', async () => {
         await expect(
           validatePrTitle('fix: Bar', {
-            requireScope: true
+            requireScope: true,
           })
         ).rejects.toThrow(
           // Should make no mention of any available scope
@@ -271,13 +281,13 @@ describe('custom types', () => {
     const types = ['foo', 'bar', 'baz'];
 
     for (let index = 0; index < inputs.length; index++) {
-      await validatePrTitle(inputs[index], {types});
+      await validatePrTitle(inputs[index], { types });
     }
   });
 
   it('throws for PR titles with an unknown type', async () => {
     await expect(
-      validatePrTitle('fix: Foobar', {types: ['foo', 'bar']})
+      validatePrTitle('fix: Foobar', { types: ['foo', 'bar'] })
     ).rejects.toThrow(
       'Unknown release type "fix" found in pull request title "fix: Foobar".'
     );
@@ -293,7 +303,7 @@ describe('description validation', () => {
     await validatePrTitle('fix: foobar', {
       subjectPattern: '^(?![A-Z]).+$',
       subjectPatternError:
-        'The subject found in the pull request title cannot start with an uppercase character.'
+        'The subject found in the pull request title cannot start with an uppercase character.',
     });
   });
 
@@ -303,7 +313,7 @@ describe('description validation', () => {
     await expect(
       validatePrTitle('fix: Foobar', {
         subjectPattern: '^(?![A-Z]).+$',
-        subjectPatternError: customError
+        subjectPatternError: customError,
       })
     ).rejects.toThrow(customError);
   });
@@ -313,7 +323,7 @@ describe('description validation', () => {
       validatePrTitle('fix: Foobar', {
         subjectPattern: '^(?![A-Z]).+$',
         subjectPatternError:
-          'The subject "{subject}" found in the pull request title "{title}" cannot start with an uppercase character.'
+          'The subject "{subject}" found in the pull request title "{title}" cannot start with an uppercase character.',
       })
     ).rejects.toThrow(
       'The subject "Foobar" found in the pull request title "fix: Foobar" cannot start with an uppercase character.'
@@ -323,7 +333,7 @@ describe('description validation', () => {
   it('throws for invalid subjects', async () => {
     await expect(
       validatePrTitle('fix: Foobar', {
-        subjectPattern: '^(?![A-Z]).+$'
+        subjectPattern: '^(?![A-Z]).+$',
       })
     ).rejects.toThrow(
       'The subject "Foobar" found in pull request title "fix: Foobar" doesn\'t match the configured pattern "^(?![A-Z]).+$".'
@@ -333,7 +343,7 @@ describe('description validation', () => {
   it('throws for only partial matches', async () => {
     await expect(
       validatePrTitle('fix: Foobar', {
-        subjectPattern: 'Foo'
+        subjectPattern: 'Foo',
       })
     ).rejects.toThrow(
       'The subject "Foobar" found in pull request title "fix: Foobar" isn\'t an exact match for the configured pattern "Foo". Please provide a subject that matches the whole pattern exactly.'
@@ -342,7 +352,7 @@ describe('description validation', () => {
 
   it('accepts valid subjects', async () => {
     await validatePrTitle('fix: foobar', {
-      subjectPattern: '^(?![A-Z]).+$'
+      subjectPattern: '^(?![A-Z]).+$',
     });
   });
 });


### PR DESCRIPTION
<!--

Thank you very much for contributing to this project!

Please make sure to have a look at the [contributors guide](https://github.com/amannn/action-semantic-pull-request/blob/master/CONTRIBUTORS.md) so you can test your changes.

For any non-trivial changes, please include a link to a workflow where you've tested the current state of this pull request (see contributors guide).

-->
